### PR TITLE
Enhance dm function for Vagrant and Azure machines

### DIFF
--- a/.functions
+++ b/.functions
@@ -137,8 +137,41 @@ function ssh-me() {
   ssh $@ "mkdir -p code && cd code && git clone https://github.com/StefanScherer/dotfiles && cd dotfiles && ./sync.sh -f"
 }
 
-function dm() {
+function dmhelper() {
   commands=(env inspect ip kill ls regenerate-certs restart rm ssh scp start status stop upgrade url help)
   case "${commands[@]}" in  *"$1"*) docker-machine $* ; return ;; esac
   eval $(docker-machine env $1)
+}
+
+function vg() {
+  pushd ~/code/windows-docker-machine
+  vagrant $*
+  popd
+}
+
+function vagrantdm() {
+  if [ "$1" == "start" ]; then vg up $2; return; fi
+  if [ "$1" == "restart" ]; then vg reload $2; return; fi
+  if [ "$1" == "stop" ]; then vg halt $2; return; fi
+  if [ "$1" == "rm" ]; then vg destroy $2 $3; return; fi
+  if [ "$1" == "status" ]; then vg status $2; return; fi
+  if [ "$1" == "rdp" ]; then vg rdp $2; return; fi
+  if [ "$1" == "regenerate-certs" ]; then vg provision $2; return; fi
+  dmhelper $*
+}
+
+function azuredm() {
+  if [ "$1" == "start" ]; then azure vm start $2 $2; return; fi
+  if [ "$1" == "restart" ]; then azure vm restart $2 $2; return; fi
+  if [ "$1" == "stop" ]; then azure vm stop $2 $2; return; fi
+  if [ "$1" == "status" ]; then azure vm show $2 $2; return; fi
+  dmhelper $*
+}
+
+function dm() {
+  vagrantmachines=(2016 1709 insider)
+  case "${vagrantmachines[@]}" in  *"${!#}"*) vagrantdm $* ; return ;; esac
+  azuremachines=(az2016 az1709)
+  case "${azuremachines[@]}" in  *"${!#}"*) azuredm $* ; return ;; esac
+  dmhelper $*
 }

--- a/README.md
+++ b/README.md
@@ -40,10 +40,6 @@ sync.sh [--all|-a] [--force|-f]
 * **....**: three dirs up
 * **.....**: four dirs up
 * **~**: go into users home directory
-* **dm**: docker-machine shortener: `dm dev` or `dm start dev` or `dm ip dev` ...
-* **dps**: like `docker ps`, but with less columns
-* **docker-rm-all**: delete all old docker containers
-* **docker-rmi-all**: delete all old docker images
 * **eachdir**: start a command for all sub directories
 * **fuck**: repeat last command with `sudo` ;-)
 * **gi**: create `.gitignore` file, see [gitignore.io](https://gitignore.io)
@@ -72,6 +68,14 @@ sync.sh [--all|-a] [--force|-f]
 * **logvi logfile**: view a log file with relative times in gvim
 * **solarize**: change between **dark** and **light** in terminal
 * **ssh-me**: copy my SSH key to remote machine and install my dotfiles there
+
+### Docker
+
+* **dps**: like `docker ps`, but with less columns
+* **dm**: docker-machine shortener: `dm dev` or `dm start dev` or `dm ip dev` ...
+  * **dm dev**  is a shortcut for `eval $(docker-machine env dev)`
+  * also integrates my [windows-docker-machine](https://github.com/StefanScherer/windows-docker-machine)'s 2016, 1709 and insider using Vagrant to start/stop them
+  * also integrates my [docker-windows-azure](https://github.com/StefanScherer/docker-windows-azure) machines az2016 and az1709 using azure cli to start/stop them
 
 ### Atom
 


### PR DESCRIPTION
Now I can use eg. `dm start 2016` to start my Vagrant [windows-docker-machine](https://github.com/StefanScherer/windows-docker-machine) or `dm start az1709` to start my Azure [docker-windows-azure](https://github.com/StefanScherer/docker-windows-azure) VM's. You don't have to switch to the Vagrant folder, the dm function does it for you (adjust the folder to your cloned git repo)
