### PR TITLE
Add "lcow" machine to bash .functions

### DIFF
--- a/.functions
+++ b/.functions
@@ -178,7 +178,7 @@ function azuredm() {
 }
 
 function dm() {
-  vagrantmachines=(2016 1709 insider)
+  vagrantmachines=(2016 1709 insider lcow)
   case "${vagrantmachines[@]}" in  *"${!#}"*) vagrantdm $* ; return ;; esac
   azuremachines=(az2016 az1709)
   case "${azuremachines[@]}" in  *"${!#}"*) azuredm $* ; return ;; esac


### PR DESCRIPTION
To support https://github.com/StefanScherer/windows-docker-machine/pull/22 I've added the additional machine "lcow" to my bash functions.

So you easily can spin up a Windows Server + LCOW in a few seconds with

```
dm start lcow
dm lcow
docker pull --platform linux alpine
docker run alpine uname -a
```