### PR TITLE
Toggle dark light for Windows from WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sync.sh [--all|-a] [--force|-f]
   Usage: timeref logfile | gvim -
 * **syncfork**: fetch from upstream and merge master branch
 * `Fn + F12`: toggle One Dark/Light theme in terminal
-* **t**: toggle Dark Mode of macOS
+* **t**: toggle Dark Mode of macOS and Windows from WSL
 * **whoseport**: Who is running that port?
 * **z**: "z foo" - cd to most frecent dir matching foo
 

--- a/bin/t
+++ b/bin/t
@@ -1,8 +1,19 @@
 #!/bin/bash
-osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to not dark mode'
 
-if [ "$(osascript -e 'tell application "System Events" to tell appearance preferences to get dark mode')" == "true" ]; then
-  osascript -e 'tell application "Terminal" to set current settings of tabs of windows to (first settings set whose name is "One Dark")'
+if [ ! -d /mnt/c ]; then
+  # Mac
+  osascript -e 'tell application "System Events" to tell appearance preferences to set dark mode to not dark mode'
+
+  if [ "$(osascript -e 'tell application "System Events" to tell appearance preferences to get dark mode')" == "true" ]; then
+    osascript -e 'tell application "Terminal" to set current settings of tabs of windows to (first settings set whose name is "One Dark")'
+  else
+    osascript -e 'tell application "Terminal" to set current settings of tabs of windows to (first settings set whose name is "One Light")'
+  fi
 else
-  osascript -e 'tell application "Terminal" to set current settings of tabs of windows to (first settings set whose name is "One Light")'
+  # Windows in WSL
+  if reg.exe query 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize' /v AppsUseLightTheme | grep -q 0x1; then
+    reg.exe add 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize' /v AppsUseLightTheme /t REG_DWORD /f /d 0 > /dev/null
+  else
+    reg.exe add 'HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Themes\Personalize' /v AppsUseLightTheme /t REG_DWORD /f /d 1 > /dev/null
+  fi
 fi


### PR DESCRIPTION
Implement the dark / light mode toggle for Windows 10 when running `t` from a WSL terminal.
